### PR TITLE
Loop Snapshot API until all votes are returned

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ENS DAO Alliance</title>
+    <title>Governance Adoption of ENS</title>
     <meta
       name="description"
       content="Dashboard to explore the adoption of ENS within popular DAOs"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -38,7 +38,7 @@ export default function App() {
       />
 
       <Header>
-        <Title>ENS DAO Alliance</Title>
+        <Title>Governance Adoption of ENS</Title>
         <Typography as="p">
           This is a dashboard to explore the adoption of ENS records within DAOs
           on Snapshot, inspired by{' '}

--- a/apps/web/src/components/atoms/Header.tsx
+++ b/apps/web/src/components/atoms/Header.tsx
@@ -5,7 +5,7 @@ export const Header = styled.header`
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 45ch;
+  max-width: 55ch;
   gap: 0.75rem;
 
   margin-right: auto;
@@ -22,7 +22,7 @@ export const Title = styled(Heading).attrs(() => ({
     font-size: ${theme.fontSizes.headingTwo};
 
     ${mq.sm.min(css`
-      font-size: ${theme.fontSizes.headingOne};
+      font-size: 2.375rem;
     `)}
   `
 )


### PR DESCRIPTION
I'm currently using the Snapshot API to get 1000 votes, sorted by voting power, from each space cast in the last 6 months. I then reduce those votes to the top 100 unique voters.

Instead, I'm trying to get the full 6 months of voting history by looping through the API until less than 1000 votes are returned, but am running into an error:
```js
{
  message: 'The `skip` argument must not be greater than 5000',
  locations: [ { line: 3, column: 7 } ],
  path: [ 'votes' ]
}
```